### PR TITLE
Modified attack-range to support ansible and test_delete_data() with orca

### DIFF
--- a/ansible/roles/attack_test/tasks/main.yml
+++ b/ansible/roles/attack_test/tasks/main.yml
@@ -27,7 +27,8 @@
 
 
 - name: running datamanipulation.py, update_timestamp set
-  command: /usr/bin/python3 datamanipulation.py --path /tmp/{{dump_name}}/{{out}} --source {{source}} --sourcetype {{sourcetype}}
+  shell:
+    cmd: /usr/bin/python3 datamanipulation.py --path /tmp/{{dump_name}}/{{out}} --source {{source}} --sourcetype {{sourcetype}}
     chdir: /tmp/
   when: update_timestamp | bool
 

--- a/ansible/roles/attack_test/tasks/main.yml
+++ b/ansible/roles/attack_test/tasks/main.yml
@@ -27,8 +27,7 @@
 
 
 - name: running datamanipulation.py, update_timestamp set
-  ansible.builtin.shell:
-    cmd: /usr/bin/python3 datamanipulation.py --path /tmp/{{dump_name}}/{{out}} --source {{source}} --sourcetype {{sourcetype}}
+  command: /usr/bin/python3 datamanipulation.py --path /tmp/{{dump_name}}/{{out}} --source {{source}} --sourcetype {{sourcetype}}
     chdir: /tmp/
   when: update_timestamp | bool
 

--- a/modules/TerraformController.py
+++ b/modules/TerraformController.py
@@ -187,7 +187,7 @@ class TerraformController(IEnvironmentController):
 
             if test_delete_data:
                 self.log.info("deleting test data from splunk for test {0}".format(test['file']))
-                splunk_sdk.delete_attack_data(instance_ip, str(self.config['attack_range_password']))
+                splunk_sdk.delete_attack_data(instance_ip, str(self.config['attack_range_password']), rest_port)
 
         return result
 

--- a/modules/splunk_sdk.py
+++ b/modules/splunk_sdk.py
@@ -211,11 +211,11 @@ def export_search(host, s, password, export_mode="raw", out=sys.stdout, username
 
 
 
-def delete_attack_data(splunk_host, splunk_password):
+def delete_attack_data(splunk_host, splunk_password, splunk_mgmt_port=8089):
     try:
         service = client.connect(
             host=splunk_host,
-            port=8089,
+            port=splunk_mgmt_port,
             username='admin',
             password=splunk_password
         )


### PR DESCRIPTION
Modified the attack-range to make it compatible with the ESCU automation framework.
Changes are ensuring below:

[**ansible/roles/attack_test/tasks/main.yml**](https://github.com/kirtankhatana-crest/attack_range/pull/1/files#diff-3f3dc604283aa46142745e9aaf4d596ebea039b081076918171e337483f0882d)
- Change key from ansible.builtin.shell to shell as it is not compatible with newer versions

[**modules/TerraformController.py**](https://github.com/kirtankhatana-crest/attack_range/pull/1/files#diff-195eba3c4750802715920f1a9aedc1445f4ae61a7ddbef60b7670b558096f559) & [**modules/splunk_sdk.py**](https://github.com/kirtankhatana-crest/attack_range/pull/1/files#diff-eccd891f263efa11f1d9b67e809882d47cbadac042b37da117461c0fb575fae3)
- added rest_port param in test_delete_data() to delete data while instance spinned up with orca.